### PR TITLE
[✨Feat/#21]: 찜 삭제(취소) API

### DIFF
--- a/src/main/java/com/joinseminar/yeogieottae/domain/hotelLike/repository/HotelLikeRepository.java
+++ b/src/main/java/com/joinseminar/yeogieottae/domain/hotelLike/repository/HotelLikeRepository.java
@@ -8,5 +8,8 @@ import java.util.Optional;
 
 public interface HotelLikeRepository extends Repository<HotelLike, Long> {
     void save(HotelLike hotelLike);
+
     Optional<HotelLike> findByHotelIdAndUser(Long hotelId, User userId);
+
+    void deleteByHotelLikeId(Long hotelLikeId);
 }

--- a/src/main/java/com/joinseminar/yeogieottae/domain/roomLike/controller/RoomLikeController.java
+++ b/src/main/java/com/joinseminar/yeogieottae/domain/roomLike/controller/RoomLikeController.java
@@ -1,5 +1,6 @@
 package com.joinseminar.yeogieottae.domain.roomLike.controller;
 
+import com.joinseminar.yeogieottae.domain.roomLike.dto.DeleteHotelOrRoomLikeRequest;
 import com.joinseminar.yeogieottae.domain.roomLike.dto.PostHotelOrRoomLikeRequest;
 import com.joinseminar.yeogieottae.domain.roomLike.service.RoomLikeService;
 import com.joinseminar.yeogieottae.global.common.dto.SuccessResponse;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import static com.joinseminar.yeogieottae.global.exception.enums.SuccessMessage.DELETE_LIKE_SUCCESS;
 import static com.joinseminar.yeogieottae.global.exception.enums.SuccessMessage.POST_LIKE_SUCCESS;
 
 @RestController
@@ -26,8 +28,19 @@ public class RoomLikeController {
             @RequestHeader Long userId,
             @RequestParam(value = "roomType") int roomType,
             @Valid @RequestBody PostHotelOrRoomLikeRequest postHotelOrRoomLikeRequest
-            ) {
+    ) {
         roomLikeService.createHotelOrRoomLike(userId, roomType, postHotelOrRoomLikeRequest.id());
         return ResponseEntity.status(HttpStatus.CREATED).body((SuccessResponse.of(POST_LIKE_SUCCESS)));
+    }
+
+    @DeleteMapping("/likes")
+    @Operation(summary = "찜(호텔&객실) 삭제(취소) API", description = "찜(호텔&객실) 삭제(취소) API 구현")
+    public ResponseEntity<SuccessResponse> deleteHotelOrRoomLike(
+            @RequestHeader Long userId,
+            @RequestParam(value = "roomType") int roomType,
+            @Valid @RequestBody DeleteHotelOrRoomLikeRequest deleteHotelOrRoomLikeRequest
+    ) {
+        roomLikeService.deleteHotelOrRoomLike(userId, roomType, deleteHotelOrRoomLikeRequest.id());
+        return ResponseEntity.ok(SuccessResponse.of(DELETE_LIKE_SUCCESS));
     }
 }

--- a/src/main/java/com/joinseminar/yeogieottae/domain/roomLike/dto/DeleteHotelOrRoomLikeRequest.java
+++ b/src/main/java/com/joinseminar/yeogieottae/domain/roomLike/dto/DeleteHotelOrRoomLikeRequest.java
@@ -1,0 +1,2 @@
+package com.joinseminar.yeogieottae.domain.roomLike.dto;public class DeleteHotelOrRoomLikeRequest {
+}

--- a/src/main/java/com/joinseminar/yeogieottae/domain/roomLike/dto/DeleteHotelOrRoomLikeRequest.java
+++ b/src/main/java/com/joinseminar/yeogieottae/domain/roomLike/dto/DeleteHotelOrRoomLikeRequest.java
@@ -1,2 +1,10 @@
-package com.joinseminar.yeogieottae.domain.roomLike.dto;public class DeleteHotelOrRoomLikeRequest {
+package com.joinseminar.yeogieottae.domain.roomLike.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteHotelOrRoomLikeRequest(
+
+        @NotNull
+        Long id
+) {
 }

--- a/src/main/java/com/joinseminar/yeogieottae/global/exception/enums/SuccessMessage.java
+++ b/src/main/java/com/joinseminar/yeogieottae/global/exception/enums/SuccessMessage.java
@@ -12,6 +12,7 @@ public enum SuccessMessage {
     GET_LIKED_ROOM_NOT_IN_COMPARE_SUCCESS(200, true, "비교하기 > 내가 찜한 목록 조회 API 요청 성공"),
     GET_COMPARE_TO_LIST_BY_ID(200, true, "비교하기 목록 불러오기를 성공했습니다."),
     POST_LIKE_SUCCESS(201, true, "찜 추가 요청 성공"),
+    DELETE_LIKE_SUCCESS(200, true, "찜 삭제 성공"),
     ;
     private final int status;
     private final boolean success;


### PR DESCRIPTION
## 📄 Work Description
- 찜 삭제(취소) API입니다.

## ⚙️ ISSUE
- closed #21 


## 📷 Screenshot
- Swagger 성공(200 ok)
<img width="564" alt="스크린샷 2024-05-17 오후 8 06 14" src="https://github.com/NOW-SOPT-APP1-YeogiEottae/YeogiEottae-Server/assets/63058347/1bb149f9-34b8-4b12-ad7a-29bc30af839e">
<br/>
<br/>
<br/>

- Swagger 실패(404 에러)
<img width="439" alt="스크린샷 2024-05-17 오후 8 08 02" src="https://github.com/NOW-SOPT-APP1-YeogiEottae/YeogiEottae-Server/assets/63058347/ec7954fc-831d-443f-ba93-5cca43a3015f">


## 💬 To Reviewers
RoomLikeRepository가 JpaRepsitory가 아닌 Repository를 상속받도록 했습니다! 당근 마켓 클론코딩에 OB 분이 다른 분 코드리뷰에 남겨주신 말씀이 생각나서 이렇게 적용해보았습니다! (성준님 클론코딩에 남겨주셨던 걸로 기억,,, 정확한 내용은 기억이 나질 않네요,,,🥲)
자세한 내용은 하단 블로그 참고해주셔도 좋을 것 같아요!!


## 🔗 Reference
[문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)](https://velog.io/@astrataraxia/JPA-Repository-%EC%83%81%EC%86%8D%EC%9D%84-%EB%B0%9B%EC%A7%80-%EC%95%8A%EB%8A%94-%EC%9D%B4%EC%9C%A0)
